### PR TITLE
Added support for recursive types and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Another approach is to inherit from ```EventEmitter::Base``` class, as the examp
 class MyEmitter < EventEmitter::Base; end
 
 my = MyEmitter.new
-my.on :event, ->(name : EventEmitter::Base::Any) do
+my.on :event do |name|
   puts "Hello #{name}"
 end
 
@@ -97,7 +97,7 @@ You can inherit from ```EventEmitter::Base``` class to add custom functionality 
 
 ```crystal
 emitter = EventEmitter::Base.new
-emitter.on :message, ->(body : EventEmitter::Base::Any) do
+emitter.on :message do |body|
   puts "> #{body}"
 end
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 authors:
   - Hugo Abonizio <hugo_abonizio@hotmail.com>
 
-crystal: 0.22.0
+crystal: 0.29.0
 
 license: MIT

--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -64,11 +64,11 @@ describe EventEmitter::Base do
     emitter.on :trigger_hash { |hash| flag_hash = hash }
 
     emitter.emit :trigger_arr, [1, 2, 3, 4, 5]
-    emitter.emit :trigger_hash, { "a" => "b" }
+    emitter.emit :trigger_hash, {"a" => "b"}
 
     sleep 100.milliseconds
     flag_arr.should eq([1, 2, 3, 4, 5])
-    flag_hash.should eq({ "a" => "b" })
+    flag_hash.should eq({"a" => "b"})
   end
 
   it "executes once" do

--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -41,9 +41,9 @@ describe EventEmitter::Base do
     flag_string = ""
     flag_bool = false
 
-    emitter.on :trigger_int, ->(int : EventEmitter::Base::Any) { flag_int = int }
-    emitter.on :trigger_string, ->(string : EventEmitter::Base::Any) { flag_string = string }
-    emitter.on :trigger_bool, ->(bool : EventEmitter::Base::Any) { flag_bool = bool }
+    emitter.on :trigger_int { |int| flag_int = int }
+    emitter.on :trigger_string { |string| flag_string = string }
+    emitter.on :trigger_bool { |bool| flag_bool = bool }
 
     emitter.emit :trigger_int, 123
     emitter.emit :trigger_string, "123"
@@ -53,6 +53,22 @@ describe EventEmitter::Base do
     flag_int.should eq(123)
     flag_string.should eq("123")
     flag_bool.should eq(true)
+  end
+
+  it "works with recursive types" do
+    emitter = EventEmitter::Base.new
+    flag_arr = [] of String
+    flag_hash = {} of String => String
+
+    emitter.on :trigger_arr { |arr| flag_arr = arr }
+    emitter.on :trigger_hash { |hash| flag_hash = hash }
+
+    emitter.emit :trigger_arr, [1, 2, 3, 4, 5]
+    emitter.emit :trigger_hash, { "a" => "b" }
+
+    sleep 100.milliseconds
+    flag_arr.should eq([1, 2, 3, 4, 5])
+    flag_hash.should eq({ "a" => "b" })
   end
 
   it "executes once" do

--- a/src/event_emitter.cr
+++ b/src/event_emitter.cr
@@ -1,26 +1,27 @@
 require "./event_emitter/*"
 
 module EventEmitter
-    alias Any = Void |
-        Nil |
-        Bool |
-        Int16 |
-        Int32 |
-        Int64 |
-        Float32 |
-        Float64 |
-        String |
-        Array(Any) |
-        Hash(Any, Any)
+  alias Any = Void |
+              Nil |
+              Bool |
+              Int16 |
+              Int32 |
+              Int64 |
+              Float32 |
+              Float64 |
+              String |
+              Array(Any) |
+              Hash(Any, Any)
 
-    # TODO: See if there isn't a better way to do this
-    def self.any(any)
-        if any.is_a?(Array)
-            any.map &.as(Any)
-        elsif any.is_a?(Hash)
-            any.map { |k, v| { k.as(Any), v.as(Any) } }.to_h
-        else
-            any
-        end
+  # TODO: See if there isn't a better way to do this
+  def self.any(any)
+    case any
+    when Array
+      any.map &.as(Any)
+    when Hash
+      any.map { |k, v| {k.as(Any), v.as(Any)} }.to_h
+    else
+      any
     end
+  end
 end

--- a/src/event_emitter.cr
+++ b/src/event_emitter.cr
@@ -1,4 +1,26 @@
 require "./event_emitter/*"
 
 module EventEmitter
+    alias Any = Void |
+        Nil |
+        Bool |
+        Int16 |
+        Int32 |
+        Int64 |
+        Float32 |
+        Float64 |
+        String |
+        Array(Any) |
+        Hash(Any, Any)
+
+    # TODO: See if there isn't a better way to do this
+    def self.any(any)
+        if any.is_a?(Array)
+            any.map &.as(Any)
+        elsif any.is_a?(Hash)
+            any.map { |k, v| { k.as(Any), v.as(Any) } }.to_h
+        else
+            any
+        end
+    end
 end


### PR DESCRIPTION
This PR adds support for recursive types (currently with Array and Hash, although it would probably be possible to do Tuple and NamedTuple as well). It also changes the API slightly as you no longer have to provide a proc to `#on` because it supports blocks now, as does `#once`.

I added a new spec to make sure things are working, and it passes. The one thing that I'm worried about is typecasting the results since they are all returned as `EventEmitter::Any`. `JSON::Any` gets around this by being an actual class with typecast methods like `as_a` and `as_i`, so we may need to do something like that to get this working right.

As it is I'm not extremely happy with the hoops I had to jump through to get Arrays and Hash's working, as to convert either one to `EventEmitter::Any` you have to typecast all of the items in the Array or Hash which leads to a new Array or Hash being created, but I don't know if it can be helped.